### PR TITLE
docs: update README for Codex prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # My C++ Solutions
 
-These are my solutions to the exercises listed inside of Introduction to Programming with C++ (3rd Edition) International Edition by Y. Daniel Liang. I will not put the exercise problem for the related code since I do not have permission to put it here. If you have any code recommendations then leave a pull request. However please remember **I am not allowed to complete the program with code syntax I did not encounter in the book.** Therefore I cannot use loops in a solution before chapter 5.
+This repository began as my solutions to the exercises in *Introduction to Programming with C++ (3rd Edition) International Edition* by Y. Daniel Liang. It now documents the transition from solving those book-based problems to crafting high-quality prompts for Codex, OpenAI's code generation model.
 
-PLEASE NOTE I AM LEARNING THIS AS A HOBBY SO UPDATES ARE NOT REGULAR.
+Starting from **Chapter 12**, each solution is designed as a Codex prompt followed by AI-generated C++ code. Earlier chapters contain hand-written solutions created while progressing through the book, sticking to the rule that no syntax is used before it appears in the text. The original problem statements are not included here due to copyright restrictions.
 
-WITH ADVANCEMENTS IN AI I AM NOT AS MOTIVATED TO LEARN THIS ANYMORE THERE WILL BE NO FURTHER UPDATES _(24th April 2024)_
+I am learning this as a hobby, so updates are not regular.
+
+## Using This Project with Codex
+
+1. Each chapter directory from Chapter 12 onward contains a `prompt.md` describing the problem.
+2. Provide the prompt to Codex and let it generate an initial C++ solution.
+3. Review, run, and refine the generated code.
+4. Commit both the prompt and the final code so readers can see the prompt–response pair.
+
+## Contributor Guidelines
+
+If you'd like to contribute:
+
+- Write prompts in Markdown with a clear title, description, constraints, and sample I/O.
+- Place prompts and generated solutions in the appropriate chapter directory.
+- Keep prompts and solutions in separate blocks and note any manual edits made to the AI-generated code.
 
 ## Completed Solutions
 
 - [Chapter 1](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_01): Introduction to Computers, Programs and C++ _(8th May 2021)_
 - [Chapter 2](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_02): Elementary Programming _(19th May 2021)_
 - [Chapter 3](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_03): Selections _(23rd May 2021)_
-
 - [Chapter 4](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_04): Mathematical Functions, Characters and Strings _(30th May 2021)_
 - [Chapter 5](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_05): Loops _(18th June 2021)_
 - [Chapter 6](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_06): Functions _(23rd June 2021)_
@@ -20,6 +34,5 @@ WITH ADVANCEMENTS IN AI I AM NOT AS MOTIVATED TO LEARN THIS ANYMORE THERE WILL B
 - [Chapter 9](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_09): Objects and Classes _(04th February 2022)_
 - [Chapter 10](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_10): Object-Oriented Thinking _(13th March 2022)_
 - [Chapter 11](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_11): Pointers and Dynamic Memory Management _(24th March 2022)_
-- [Chapter 12](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_12): Templates, Vectors and Stacks _(Pending)_
-
+- [Chapter 12](https://github.com/Kevin-Oudai/my_cpp_solutions/tree/main/chapter_12): Templates, Vectors and Stacks _(Pending – Codex prompt format)_
 


### PR DESCRIPTION
## Summary
- document evolution from book exercises to Codex prompt collection
- add guidelines for using prompts and contributing new ones

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689487d8bd88832fbc5cea08db956904